### PR TITLE
Bugfix/tracking project association

### DIFF
--- a/app/controllers/trackings_controller.rb
+++ b/app/controllers/trackings_controller.rb
@@ -52,7 +52,6 @@ class TrackingsController < ApplicationController
   private
     # Never trust parameters from the scary internet, only allow the white list through.
     def tracking_params
-      params.require(:tracking).permit(:content)
-      params.require(:tracking).permit(:project_id)
+      params.require(:tracking).permit(:content, :project_id)
     end
 end

--- a/app/views/trackings/_form.html.erb
+++ b/app/views/trackings/_form.html.erb
@@ -15,9 +15,9 @@
     <%= f.label :content %>
     <%= f.text_field :content, class: "form-control", id: "duration-picker" %>
   </div>
-  
-  <%= collection_select(:project, :project_id, Project.all, :id, :title) %>
-  
+
+  <%= collection_select(:tracking, :project_id, Project.all, :id, :title) %>
+
   <p>Missing the project? <%= link_to 'Add it', new_project_path %>.</p>
 
   <div class="actions">


### PR DESCRIPTION
This fixes the problem of creating a `Tracking` with a blank association.  Probably be a good idea to add validation to catch this as well.